### PR TITLE
F/ch3 5/card detail page/sunghyun son

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import HomePage from '@pages/Home'
+import CardPage from '@pages/Card'
 import TestPage from '@pages/Test'
 
 function App() {
@@ -7,6 +8,7 @@ function App() {
     <BrowserRouter>
       <Routes>
         <Route path="/" Component={HomePage} />
+        <Route path="/card/:id" Component={CardPage} />
         <Route path="/test" Component={TestPage} />
       </Routes>
     </BrowserRouter>

--- a/src/components/home/CardList.tsx
+++ b/src/components/home/CardList.tsx
@@ -1,10 +1,10 @@
-import ListRow from '@shared/ListRow'
 import { useInfiniteQuery } from 'react-query'
 import getCards from '@remote/card'
 import { flatten } from 'lodash'
-import Button from '@shared/Button'
 import InfiniteScroll from 'react-infinite-scroll-component'
 import { useCallback } from 'react'
+import ListRow from '@shared/ListRow'
+import Badge from '@shared/Badge'
 
 function CardList() {
   const {
@@ -53,7 +53,9 @@ function CardList() {
               contents={
                 <ListRow.Texts title={`${idx + 1}위`} subTitle={card.name} />
               }
-              right={card.payback != null ? <div>{card.payback}</div> : null}
+              right={
+                card.payback != null ? <Badge label={card.payback} /> : null
+              }
               withArrow={true}
             ></ListRow>
           )

--- a/src/components/home/CardList.tsx
+++ b/src/components/home/CardList.tsx
@@ -5,6 +5,7 @@ import InfiniteScroll from 'react-infinite-scroll-component'
 import { useCallback } from 'react'
 import ListRow from '@shared/ListRow'
 import Badge from '@shared/Badge'
+import { useNavigate } from 'react-router-dom'
 
 function CardList() {
   const {
@@ -33,6 +34,8 @@ function CardList() {
     fetchNextPage()
   }, [fetchNextPage, hasNextPage, isFetching])
 
+  const navigate = useNavigate()
+
   if (data == null) {
     return null
   }
@@ -59,6 +62,9 @@ function CardList() {
                   card.payback != null ? <Badge label={card.payback} /> : null
                 }
                 withArrow={true}
+                onClick={() => {
+                  navigate(`card/${card.id}`)
+                }}
               ></ListRow>
             )
           })}

--- a/src/components/home/CardList.tsx
+++ b/src/components/home/CardList.tsx
@@ -47,20 +47,22 @@ function CardList() {
         next={loadMore}
         scrollThreshold="100px"
       >
-        {cards.map((card, idx) => {
-          return (
-            <ListRow
-              key={card.id}
-              contents={
-                <ListRow.Texts title={`${idx + 1}위`} subTitle={card.name} />
-              }
-              right={
-                card.payback != null ? <Badge label={card.payback} /> : null
-              }
-              withArrow={true}
-            ></ListRow>
-          )
-        })}
+        <ul>
+          {cards.map((card, idx) => {
+            return (
+              <ListRow
+                key={card.id}
+                contents={
+                  <ListRow.Texts title={`${idx + 1}위`} subTitle={card.name} />
+                }
+                right={
+                  card.payback != null ? <Badge label={card.payback} /> : null
+                }
+                withArrow={true}
+              ></ListRow>
+            )
+          })}
+        </ul>
       </InfiniteScroll>
     </div>
   )

--- a/src/components/home/CardList.tsx
+++ b/src/components/home/CardList.tsx
@@ -45,6 +45,7 @@ function CardList() {
         hasMore={hasNextPage}
         loader={<></>}
         next={loadMore}
+        scrollThreshold="100px"
       >
         {cards.map((card, idx) => {
           return (

--- a/src/components/shared/Badge.tsx
+++ b/src/components/shared/Badge.tsx
@@ -1,0 +1,24 @@
+import { colors } from '@/styles/colorPalette'
+import styled from '@emotion/styled'
+import Text from '@shared/Text'
+
+interface BadgeProps {
+  label: string
+}
+
+function Badge({ label }: BadgeProps) {
+  return (
+    <Container>
+      <Text bold={true} typography="t7" color="white">
+        {label}
+      </Text>
+    </Container>
+  )
+}
+
+const Container = styled.div`
+  border-radius: 12px;
+  background-color: ${colors.blue};
+  padding: 2px 8px;
+`
+export default Badge

--- a/src/components/shared/FixedBottomButton.tsx
+++ b/src/components/shared/FixedBottomButton.tsx
@@ -1,0 +1,42 @@
+import { css } from '@emotion/react'
+import styled from '@emotion/styled'
+import { createPortal } from 'react-dom'
+
+import { colors } from '@styles/colorPalette'
+import Button from '@shared/Button'
+
+interface FixedBottomButtonProps {
+  label: string
+  onClick: () => void
+}
+
+function FixedBottomButton({ label, onClick }: FixedBottomButtonProps) {
+  const $portal_root = document.getElementById('root_portal')
+  if ($portal_root == null) {
+    return null
+  }
+
+  return createPortal(
+    <Container>
+      <Button full={true} onClick={onClick} css={buttonStyles} size="medium">
+        {label}
+      </Button>
+    </Container>,
+    $portal_root,
+  )
+}
+
+const Container = styled.div`
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: ${colors.white};
+  padding: 20px 10px 8px;
+`
+
+const buttonStyles = css`
+  border-radius: 8px;
+`
+
+export default FixedBottomButton

--- a/src/pages/Card.tsx
+++ b/src/pages/Card.tsx
@@ -1,10 +1,13 @@
 import { useParams } from 'react-router-dom'
 import { useQuery } from 'react-query'
+import { css } from '@emotion/react'
 
 import Top from '@shared/Top'
 import { getCard } from '@remote/card'
 import ListRow from '@shared/ListRow'
 import FixedBottomButton from '@shared/FixedBottomButton'
+import Flex from '@shared/Flex'
+import Text from '@shared/Text'
 
 function CardPage() {
   const { id = '' } = useParams()
@@ -20,7 +23,6 @@ function CardPage() {
   const { name, corpName, promotion, tags, benefit } = data
   let subTitle =
     promotion != null ? removeHtml(promotion.title) : tags.join(' ,')
-  console.log(subTitle)
 
   return (
     <>
@@ -38,6 +40,15 @@ function CardPage() {
           )
         })}
       </ul>
+
+      {promotion != null ? (
+        <Flex direction="column" css={termContainerStyles}>
+          <Text bold={true} typography="t4">
+            유의사항
+          </Text>
+          <Text typography="t7">{removeHtml(promotion.terms)}</Text>
+        </Flex>
+      ) : null}
       <FixedBottomButton label="신청하기" onClick={() => {}} />
     </>
   )
@@ -89,5 +100,10 @@ function IconCheck() {
     </svg>
   )
 }
+
+const termContainerStyles = css`
+  margin-top: 80px;
+  padding: 0 24px 80px 24px;
+`
 
 export default CardPage

--- a/src/pages/Card.tsx
+++ b/src/pages/Card.tsx
@@ -1,0 +1,5 @@
+function CardPage() {
+  return <div>CardPage</div>
+}
+
+export default CardPage

--- a/src/pages/Card.tsx
+++ b/src/pages/Card.tsx
@@ -1,5 +1,93 @@
+import { useParams } from 'react-router-dom'
+import { useQuery } from 'react-query'
+
+import Top from '@shared/Top'
+import { getCard } from '@remote/card'
+import ListRow from '@shared/ListRow'
+import FixedBottomButton from '@shared/FixedBottomButton'
+
 function CardPage() {
-  return <div>CardPage</div>
+  const { id = '' } = useParams()
+  // card와 id를 묶어서 캐시 key값 생성
+  const { data } = useQuery(['card', id], () => getCard(id), {
+    enabled: id !== '', //id가 empty가 아닐때 fetch 해옴
+  })
+
+  if (data == null) {
+    return null
+  }
+
+  const { name, corpName, promotion, tags, benefit } = data
+  let subTitle =
+    promotion != null ? removeHtml(promotion.title) : tags.join(' ,')
+  console.log(subTitle)
+
+  return (
+    <>
+      <Top title={`${name} ${corpName}`} subTitle={subTitle}></Top>
+      <ul>
+        {benefit.map((text, index) => {
+          return (
+            <ListRow
+              key={text}
+              left={<IconCheck />}
+              contents={
+                <ListRow.Texts title={`혜택 ${index + 1}`} subTitle={text} />
+              }
+            />
+          )
+        })}
+      </ul>
+      <FixedBottomButton label="신청하기" onClick={() => {}} />
+    </>
+  )
+}
+
+function removeHtml(text: string) {
+  let output = ''
+
+  for (let i = 0; i < text.length; i++) {
+    if (text[i] === '<') {
+      for (let j = i + 1; j < text.length; j++) {
+        if (text[j] === '>') {
+          i = j
+          break
+        }
+      }
+    } else {
+      output += text[i]
+    }
+  }
+
+  return output
+}
+
+function IconCheck() {
+  return (
+    <svg
+      fill="none"
+      height="20"
+      viewBox="0 0 48 48"
+      width="20"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <rect fill="white" fillOpacity="0.01" height="48" width="48" />
+      <path
+        d="M24 44C29.5228 44 34.5228 41.7614 38.1421 38.1421C41.7614 34.5228 44 29.5228 44 24C44 18.4772 41.7614 13.4772 38.1421 9.85786C34.5228 6.23858 29.5228 4 24 4C18.4772 4 13.4772 6.23858 9.85786 9.85786C6.23858 13.4772 4 18.4772 4 24C4 29.5228 6.23858 34.5228 9.85786 38.1421C13.4772 41.7614 18.4772 44 24 44Z"
+        fill="#2F88FF"
+        stroke="black"
+        strokeLinejoin="round"
+        strokeWidth="4"
+      />
+      <path
+        d="M16 24L22 30L34 18"
+        stroke="white"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="4"
+      />
+    </svg>
+  )
 }
 
 export default CardPage

--- a/src/remote/card.ts
+++ b/src/remote/card.ts
@@ -1,5 +1,7 @@
 import {
   collection,
+  doc,
+  getDoc,
   getDocs,
   limit,
   query,
@@ -34,6 +36,15 @@ async function getCards(pageParam?: QuerySnapshot) {
   }))
 
   return { items, lastVisible }
+}
+
+export async function getCard(id: string) {
+  const snapShot = await getDoc(doc(store, COLLECTIONS.CARD, id))
+
+  return {
+    id,
+    ...(snapShot.data() as Card),
+  }
 }
 
 export default getCards


### PR DESCRIPTION
홈 화면 개선
- 마크업 개선: li tag를 ul tag로 wrap
- 페이징 작업을 민감하게 반응했던 부분에서 최적화 목적으로 둔감하게 적용(InfiniteScroll에 scrollThreshold 적용)

카드 상세 페이지 구현
- 카드 상세 페이지 경로 추가 및 페이지 화면 component 구현
  - 상세페이지 경로: card data가 가진 id로 사용하여 경로 이동( react-route ), id발급 firebase에서 진행해줌
  - 페이지 화면에 top, fixed bottom bottom, content(benefit, 유의사항) 보여줌(pages/Card.tsx 구현)
  - 세부 기능 구현: 특정 card data를 가져오는 서비스 구현, html tag 단순 제거 기능, fixed 버튼 페이지 분리