### PR TITLE
[bugfix] 카드 상세 페이지로 이동시 비정상 오류 발생

### DIFF
--- a/src/pages/Card.tsx
+++ b/src/pages/Card.tsx
@@ -95,6 +95,7 @@ function CardPage() {
 }
 
 function removeHtml(text: string) {
+  if (text == null) return
   let output = ''
 
   for (let i = 0; i < text.length; i++) {


### PR DESCRIPTION
- 카드 목록페이지에서 <2위 FINETECH카드(대한항공) KB국민카드> 클릭시 비정상 오류 발생
  - 원인: promotion 내부에 title이 없는 mock 데이터로 인해 title에 접근하여 오류 발생
  - 해결: title 접근하는 함수에서 예외처리 추가