### PR TITLE
[feat] user 정보 페이지 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import SigninPage from '@pages/Signin'
 import SignupPage from '@pages/Signup'
 import ApplyPage from '@pages/Apply'
 import ApplyDone from '@pages/ApplyDone'
+import MyPage from '@pages/My'
 
 import PrivateRouter from '@components/auth/PrivateRouter'
 
@@ -38,6 +39,14 @@ function App() {
           element={
             <PrivateRouter>
               <ApplyDone />
+            </PrivateRouter>
+          }
+        />
+        <Route
+          path="/my"
+          element={
+            <PrivateRouter>
+              <MyPage />
             </PrivateRouter>
           }
         />

--- a/src/components/shared/MyImage.tsx
+++ b/src/components/shared/MyImage.tsx
@@ -1,0 +1,94 @@
+import { ChangeEvent } from 'react'
+import styled from '@emotion/styled'
+import { getAuth, updateProfile } from 'firebase/auth'
+import { getDownloadURL, ref, uploadBytes } from 'firebase/storage'
+import { collection, doc, updateDoc } from 'firebase/firestore'
+import { useSetRecoilState } from 'recoil'
+
+import { app, storage, store } from '@remote/firebase'
+import useUser from '@hooks/auth/useUser'
+import { COLLECTIONS } from '@constants'
+import { userAtom } from '@atoms/user'
+
+function MyImage({
+  size = 40,
+  mode = 'default',
+}: {
+  size?: number
+  mode?: 'default' | 'upload'
+}) {
+  const user = useUser()
+  const setUser = useSetRecoilState(userAtom)
+
+  const currentUser = getAuth(app).currentUser
+
+  const handleUploadImage = async (e: ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files
+    if (files == null || user == null || currentUser == null) {
+      return
+    }
+
+    const fileName = files[0].name
+    const storageRef = ref(storage, `users/${user.uid}/${fileName}`)
+    // firebase storage에 저장
+    const uploaded = await uploadBytes(storageRef, files[0])
+
+    // storage에서 url 가져와서 user-auth에 업데이트
+    const downloadUrl = await getDownloadURL(uploaded.ref)
+    await updateProfile(currentUser, {
+      photoURL: downloadUrl,
+    })
+
+    // firebase db에서 url 업데이트
+    await updateDoc(doc(collection(store, COLLECTIONS.USER), currentUser.uid), {
+      photoURL: downloadUrl,
+    })
+
+    setUser({
+      ...user,
+      photoURL: downloadUrl,
+    })
+
+    console.log('updateDoc', uploaded)
+    console.log('downloadUrl', downloadUrl)
+  }
+
+  return (
+    <Container>
+      <img
+        src={
+          user?.photoURL ||
+          'https://cdn1.iconfinder.com/data/icons/user-pictures/100/male3-64.png'
+        }
+        alt="유저의 이미지"
+        width={size}
+        height={size}
+      />
+      {mode === 'upload' ? (
+        <input type="file" accept="image/*" onChange={handleUploadImage} />
+      ) : null}
+    </Container>
+  )
+}
+
+const Container = styled.div`
+  position: relative;
+  display: inline-block;
+  cursor: pointer;
+
+  & img {
+    border-radius: 100%;
+  }
+
+  & input[type='file'] {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    opacity: 0;
+    cursor: pointer;
+  }
+`
+
+export default MyImage

--- a/src/components/shared/Navbar.tsx
+++ b/src/components/shared/Navbar.tsx
@@ -1,12 +1,12 @@
 import { useCallback } from 'react'
 import { Link, useLocation } from 'react-router-dom'
 import { css } from '@emotion/react'
-import { signOut } from 'firebase/auth'
+
 import Flex from '@shared/Flex'
 import Button from '@shared/Button'
-import { colors } from '@/styles/colorPalette'
+import MyImage from '@shared/MyImage'
+import { colors } from '@styles/colorPalette'
 import useUser from '@hooks/auth/useUser'
-import { auth } from '@remote/firebase'
 
 function Navbar() {
   const location = useLocation()
@@ -14,12 +14,10 @@ function Navbar() {
     ['/signin', '/signup'].includes(location.pathname) === false
   const user = useUser()
 
-  const handleLogout = useCallback(() => {
-    signOut(auth)
-  }, [])
   const renderButton = useCallback(() => {
     if (user != null) {
-      return <Button onClick={handleLogout}>로그아웃</Button>
+      //TODO 클릭시 user 정보 페이지로 이동 기능 추가
+      return <MyImage />
     }
 
     if (showSignButton) {

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -2,4 +2,5 @@ export interface User {
   uid: string
   email: string
   displayName: string
+  photoURL?: string
 }

--- a/src/pages/My.tsx
+++ b/src/pages/My.tsx
@@ -1,0 +1,32 @@
+import { useCallback } from 'react'
+import { signOut } from 'firebase/auth'
+
+import Button from '@shared/Button'
+import Flex from '@shared/Flex'
+import MyImage from '@shared/MyImage'
+import Spacing from '@shared/Spacing'
+import Text from '@shared/Text'
+
+import { auth } from '@remote/firebase'
+import useUser from '@hooks/auth/useUser'
+
+function MyPage() {
+  const user = useUser()
+  const handleLogout = useCallback(() => {
+    signOut(auth)
+  }, [])
+
+  return (
+    <Flex direction="column" align="center">
+      <Spacing size={40} />
+      <MyImage size={80} mode="upload" />
+      <Spacing size={20} />
+      <Text bold={true}>{user?.displayName}</Text>
+
+      <Spacing size={20} />
+      <Button onClick={handleLogout}>로그아웃</Button>
+    </Flex>
+  )
+}
+
+export default MyPage

--- a/src/remote/firebase.ts
+++ b/src/remote/firebase.ts
@@ -1,6 +1,7 @@
 import { initializeApp } from 'firebase/app'
 import { getAuth } from 'firebase/auth'
 import { getFirestore } from 'firebase/firestore'
+import { getStorage } from 'firebase/storage'
 
 const {
   REACT_APP_API_KEY,
@@ -26,3 +27,4 @@ const firebaseConfig = {
 export const app = initializeApp(firebaseConfig)
 export const auth = getAuth(app)
 export const store = getFirestore(app)
+export const storage = getStorage(app)


### PR DESCRIPTION
- Navbar(헤더영역)에 user Image로 변경(MyImage 컴포넌트)
- MyImage 컴포넌트에 이미지 업로드 기능 구현
  - firebase storage에 이미지를 저장하고, 이미지의 Url값을 auth와 firebase database에 저장
  - 이슈: 테스트하면서 firebase database에 user 계정을 날려서 업데이트가 안됨
  - 서버 업데이트 완료되면, 상태 정보를 업데이트하여 user의 프로필 사진도 변경(useSetRecoilState 사용)