### PR TITLE
[refactor] layoutshift 이슈 해결

### DIFF
--- a/src/components/home/AdBanners.tsx
+++ b/src/components/home/AdBanners.tsx
@@ -15,7 +15,18 @@ import Text from '@shared/Text'
 import { colors } from '@styles/colorPalette'
 
 function AdBanners() {
-  const { data } = useQuery(['adBanners'], () => getAdBanners())
+  const { data, isLoading } = useQuery(['adBanners'], () => getAdBanners())
+  if (data == null || isLoading) {
+    // data가 로딩 중일때, 공간을 잡아두는 역할로 layoutshift를 방지하기 위함
+    return (
+      <Container>
+        <Flex direction="column" css={bannerContainerStyles}>
+          <Text bold={true}>&nbsp;</Text>
+          <Text typography="t7">&nbsp;</Text>
+        </Flex>
+      </Container>
+    )
+  }
 
   return (
     <Container>

--- a/src/components/home/CardList.tsx
+++ b/src/components/home/CardList.tsx
@@ -25,6 +25,7 @@ function CardList() {
       getNextPageParam: (snapshot) => {
         return snapshot.lastVisible
       },
+      suspense: true,
     },
   )
 
@@ -47,7 +48,7 @@ function CardList() {
       <InfiniteScroll
         dataLength={cards.length}
         hasMore={hasNextPage}
-        loader={<></>}
+        loader={<ListRow.Skeleton />}
         next={loadMore}
         scrollThreshold="100px"
       >

--- a/src/components/shared/ListRow.tsx
+++ b/src/components/shared/ListRow.tsx
@@ -1,7 +1,8 @@
 import { css } from '@emotion/react'
 import Flex from '@shared/Flex'
+import Skeleton from '@shared/Skeleton'
+import Spacing from '@shared/Spacing'
 import Text from '@shared/Text'
-
 interface ListRowProps {
   left?: React.ReactNode
   contents: React.ReactNode
@@ -45,13 +46,33 @@ function ListRowTexts({
   title,
   subTitle,
 }: {
-  title: string
-  subTitle: string
+  title: React.ReactNode
+  subTitle: React.ReactNode
 }) {
   return (
     <Flex direction="column">
       <Text bold={true}>{title}</Text>
       <Text typography="t7">{subTitle}</Text>
+    </Flex>
+  )
+}
+
+function ListRowSkeleton() {
+  return (
+    <Flex as="li" css={listRowContainerStyles} align="center">
+      <Flex css={listRowLeftStyles}></Flex>
+      <Flex css={listRowContentsStyles}>
+        <ListRow.Texts
+          title={
+            <>
+              <Skeleton width={67} height={23} />
+              <Spacing size={2} />
+            </>
+          }
+          subTitle={<Skeleton width={85} height={20} />}
+        />
+      </Flex>
+      <IconArrowRight />
     </Flex>
   )
 }
@@ -66,5 +87,6 @@ function IconArrowRight() {
 }
 
 ListRow.Texts = ListRowTexts
+ListRow.Skeleton = ListRowSkeleton
 
 export default ListRow

--- a/src/components/shared/Skeleton.ts
+++ b/src/components/shared/Skeleton.ts
@@ -1,0 +1,28 @@
+import styled from '@emotion/styled'
+import { keyframes } from '@emotion/react'
+import { colors } from '@styles/colorPalette'
+
+const opacity = keyframes`
+    0% {
+        opacity: 1;
+    }
+
+    50% {
+        opacity: 0.4;
+    }
+
+    100% {
+        opacity: 1;
+    }
+`
+
+const Skeleton = styled.div<{ width: number; height: number }>(
+  ({ width, height }) => ({
+    width,
+    height,
+    backgroundColor: colors.grey,
+    animation: `${opacity} 2s ease-in-out 0.5s infinite`,
+  }),
+)
+
+export default Skeleton

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,6 +1,8 @@
+import { Suspense } from 'react'
 import Top from '@shared/Top'
 import AdBanners from '@components/home/AdBanners'
-import CardList from '@/components/home/CardList'
+import CardList from '@components/home/CardList'
+import ListRow from '@shared/ListRow'
 
 function HomePage() {
   return (
@@ -10,7 +12,13 @@ function HomePage() {
         subTitle="회원님들을 위해 혜택 좋은 카드를 모아놨습니다."
       />
       <AdBanners />
-      <CardList />
+      <Suspense
+        fallback={[...new Array(10)].map((_, idx) => (
+          <ListRow.Skeleton key={idx} />
+        ))}
+      >
+        <CardList />
+      </Suspense>
     </div>
   )
 }


### PR DESCRIPTION
- layoutshift: 누르려는 버튼이 다른 상위 요소가 layout이 되면서 누르고 못하고 다른 요소를 누르는 현상으로 의도하지 않은 action이 발생하면 사용자에게 불편한 경험을 줄 수 있음
- 해결방안: 비동기 작업이 발생하는 요소 미리 영역을 잡아두고 skelecton ui을 렌더링 하는 방안

- AdBanner 컴포넌트가 로딩중일때, 빈 화면 렌더링
- CardList 컴포넌트가 로딩중일때 ListRow.Skeleton 렌더링
  - ListRow의 prop에 Skelecton 컴포넌트 렌더링